### PR TITLE
Remove omitted node with omitted children in choose category table

### DIFF
--- a/datasets/models.py
+++ b/datasets/models.py
@@ -205,6 +205,12 @@ class TaxonomyNode(models.Model):
         else:  # several parents
             return ' (many parents) > {}'.format(self.name)
 
+    @property
+    def self_and_children_omitted(self):
+        """ Returns True if the node and all its children are omitted """
+        all_children = self.taxonomy.get_all_children(self.node_id)
+        return all(omitted for omitted in [child.omitted for child in all_children] + [self.omitted])
+
 
 class Dataset(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)

--- a/datasets/views.py
+++ b/datasets/views.py
@@ -303,7 +303,8 @@ def dataset_taxonomy_table_choose(request, short_name):
         # choose a category at the given node_id level
         if node_id != str(0):
             if node_id in taxonomy.get_nodes_at_level(0).values_list('node_id', flat=True):
-                nodes = taxonomy.get_children(node_id)
+                # remove node that them and all their children are omitted
+                nodes = [node for node in taxonomy.get_children(node_id) if not node.self_and_children_omitted]
             else:
                 end_of_table = True  # end of continue, now the user will choose a category to annotate
                 nodes = taxonomy.get_all_children(node_id) + [taxonomy.get_element_at_id(node_id)] + taxonomy.get_all_parents(node_id)


### PR DESCRIPTION
Added `self_and_children_omitted` method in `TaxonomyNode` model for knowing if a category and all its children are omitted.
The method is then used in `dataset_taxonomy_table_choose` view function for filtering out the categories that should not appear in the (1st or) 2nd level of the table as explained in #63.

This process is doing some new queries to the database, but it seems hard to avoid these _late queries_ without adding another field in `TaxonomyNode` referring to the `self_and_children_omitted` propriety.
Because 1st and 2nd level of the ontology are not very large, I guess it is not a bid deal.