### PR TITLE
Designing Explicit part of Training phase - Iss71

### DIFF
--- a/datasets/models.py
+++ b/datasets/models.py
@@ -179,6 +179,7 @@ class TaxonomyNode(models.Model):
     nb_ground_truth = models.IntegerField(default=0)
     
     def as_dict(self):
+        parents = self.get_parents()
         return {"name": self.name,
                 "node_id": self.node_id,
                 "id": self.id,
@@ -187,8 +188,9 @@ class TaxonomyNode(models.Model):
                 "abstract": self.abstract,
                 "omitted": self.omitted,
                 "freesound_examples": [example.freesound_id for example in self.freesound_examples.all()],
-                "parent_ids": [parent.node_id for parent in self.parents.all()],
-                "child_ids": [child.node_id for child in self.children.all()],
+                "parent_ids": [parent.node_id for parent in parents],
+                "child_ids": [child.node_id for child in self.get_children()],
+                "sibling_ids": [sibling.node_id for sibling in self.get_siblings(parents)],
                 "nb_ground_truth": self.nb_ground_truth,
                 "nb_user_contributions": self.num_user_contributions}
 

--- a/datasets/models.py
+++ b/datasets/models.py
@@ -219,6 +219,17 @@ class TaxonomyNode(models.Model):
     def num_user_contributions(self):
         return Vote.objects.filter(annotation__taxonomy_node=self).count()
 
+    def get_parents(self):
+        return self.parents.all()
+
+    def get_children(self):
+        return self.children.all()
+
+    def get_siblings(self, parents=None):
+        if not parents:
+            parents = self.get_parents()
+        return TaxonomyNode.objects.filter(parents__in=parents)
+
 
 class Dataset(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)

--- a/datasets/models.py
+++ b/datasets/models.py
@@ -506,9 +506,16 @@ class Profile(models.Model):
 
     @property
     def contributed_recently(self):
+        return self.contributed_before(3)
+
+    @property
+    def contributed_two_weeks_ago(self):
+        return self.contributed_before(14)
+
+    def contributed_before(self, days_ago):
         last_contribution_date = self.user.votes.order_by('-created_at')[0].created_at
-        three_days_ago = timezone.now() - datetime.timedelta(days=3)
-        return last_contribution_date > three_days_ago
+        past_date = timezone.now() - datetime.timedelta(days=days_ago)
+        return last_contribution_date > past_date
 
 
 @receiver(post_save, sender=User)

--- a/datasets/models.py
+++ b/datasets/models.py
@@ -230,7 +230,7 @@ class TaxonomyNode(models.Model):
     def get_siblings(self, parents=None):
         if not parents:
             parents = self.get_parents()
-        return TaxonomyNode.objects.filter(parents__in=parents)
+        return TaxonomyNode.objects.filter(parents__in=parents).exclude(node_id=self.node_id)
 
 
 class Dataset(models.Model):

--- a/datasets/templates/datasets/contribute.html
+++ b/datasets/templates/datasets/contribute.html
@@ -11,10 +11,7 @@
         <tbody>
             <tr>
                 <td>
-                    <a href="{% url 'choose_category' dataset.short_name %}" class="ui big right labeled icon blue button"><i class="checkmark box icon"></i>Validate category annotations</a>
-                </td>
-                <td>
-                    Read <a href="{% url 'contribute-validate-annotations' dataset.short_name %}?help=1">task instructions</a>
+                    <a href="{% url 'contribute-validate-annotations' dataset.short_name %}?help=1" class="ui big right labeled icon blue button"><i class="checkmark box icon"></i>Validate category annotations</a>
                 </td>
             </tr>
         </tbody>

--- a/datasets/templates/datasets/contribute_validate_annotations_category.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_category.html
@@ -37,11 +37,12 @@
             $('#form_container').css("visibility", "visible");
         }
 
-        $( document ).ready(function() {
+        $(document).ready(function() {
             setTimeout(function(){
                 $('#start_annotating_button').removeClass('disabled');
                 $('#start_annotating_button_div').removeAttr("data-tooltip");
             }, 10000);
+            if ('{{skip_tempo}}'=='True'){show_form();}
         });
     </script>
 {% endblock %}
@@ -70,7 +71,7 @@
                 <div class="six wide column right aligned">
                     {% if annotations_forms %}
                         <a href="javascript:void(0);" onclick="$('#help_modal').modal('show');" class="ui orange button right labeled icon">Help <i class="help icon"></i></a>
-                        <a href="{% url 'contribute-validate-annotations-category' dataset.short_name main_node_data.url_id %}" class="ui button right labeled teal icon">Choose other sounds <i class="refresh icon"></i></a>
+                        <a href="{% url 'contribute-validate-annotations-category' dataset.short_name main_node_data.url_id %}?new_sounds=True" class="ui button right labeled teal icon">Choose other sounds <i class="refresh icon"></i></a>
                     {% endif %}
                 </div>
             </div>
@@ -134,7 +135,7 @@
             </p>
         </div>
         <div class="actions">
-            <a href="{% url 'contribute-validate-annotations-category' dataset.short_name main_node_data.url_id %}" class="green ui inverted right labeled button icon"><i class="plus icon"></i> Give me more sounds from this category</a>
+            <a href="{% url 'contribute-validate-annotations-category' dataset.short_name main_node_data.url_id %}?new_sounds=True" class="green ui inverted right labeled button icon"><i class="plus icon"></i> Give me more sounds from this category</a>
             <a href="{% url 'choose_category' dataset.short_name %}" class="blue ui inverted button right labeled icon"><i class="refresh icon"></i> Choose another category</a>
         </div>
     </div>

--- a/datasets/templates/datasets/contribute_validate_annotations_category.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_category.html
@@ -34,7 +34,7 @@
 
         function show_form() {
             $('#start_annotating_button').hide();
-            $('#form_container').show();
+            $('#form_container').css("visibility", "visible");
         }
     </script>
 {% endblock %}
@@ -52,10 +52,10 @@
     {% taxonomy_node_minimal_data dataset node.node_id as main_node_data %}
     <br>
     {% if not main_node_data.is_omitted %}
-        <div id="start_annotating_button" class="ui center aligned segment">
+        <div id="start_annotating_button" class="ui center aligned basic segment">
             <button class="red ui button center" onclick="show_form();">Start annotating</button>
         </div>
-        <div id="form_container" hidden>
+        <div id="form_container" style="visibility: hidden">
             <div class="ui grid">
                 <div class="ten wide column">
                     <h2>Is <div class="ui big label">{{ node.name }}</div> present in the following sounds?</h2>

--- a/datasets/templates/datasets/contribute_validate_annotations_category.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_category.html
@@ -31,6 +31,11 @@
             window.open('https://freesound.org/s/' + freesound_id + '/');
             $('#id_form-' + sound_idx + '-visited_sound').val(true);
         }
+
+        function show_form() {
+            $('#start_annotating_button').hide();
+            $('#form_container').show();
+        }
     </script>
 {% endblock %}
 {% block content %}
@@ -47,62 +52,68 @@
     {% taxonomy_node_minimal_data dataset node.node_id as main_node_data %}
     <br>
     {% if not main_node_data.is_omitted %}
-        <div class="ui grid">
-            <div class="ten wide column">
-                <h2>Is <div class="ui big label">{{ node.name }}</div> present in the following sounds?</h2>
-            </div>
-            <div class="six wide column right aligned">
-                {% if annotations_forms %}
-                    <a href="javascript:void(0);" onclick="$('#help_modal').modal('show');" class="ui orange button right labeled icon">Help <i class="help icon"></i></a>
-                    <a href="{% url 'contribute-validate-annotations-category' dataset.short_name main_node_data.url_id %}" class="ui button right labeled teal icon">Choose other sounds <i class="refresh icon"></i></a>
-                {% endif %}
-            </div>
+        <div id="start_annotating_button" class="ui center aligned segment">
+            <button class="red ui button center" onclick="show_form();">Start annotating</button>
         </div>
-        <br>
-        <form id="votes_form" class="ui form">{% csrf_token %}
-            {{ formset.management_form }}
-            <div class="ui centered cards">
-                {% for annotation, form in annotations_forms %}
-                    <div class="card" id="row_annotation_{{ forloop.counter0 }}">
-                        {% with annotation.sound_dataset.sound.freesound_id as fsid  %}
-                            <div class="content">
-                                <div class="right floated meta"><a href="javascript:void(0);" onclick="openFreesoundSoundPage('{{ fsid }}', '{{ forloop.counter0 }}');"><i class="external icon"></i></a></div>
-                                <div class="header">#{{ forloop.counter }}</div>
-
-                                <div class="description">
-                                    <div class="ui grid">
-                                        <div class="eight wide column">
-                                            {{ fsid| fs_embed | safe }}
-                                        </div>
-                                        <div class="eight wide column vote_card_form">
-                                            {{ form.vote }}
-                                            {{ form.annotation_id }}
-                                            {{ form.visited_sound }}
-                                        </div>
-                                    </div>
-
-                                </div>
-                            </div>
-                        {% endwith %}
-                    </div>
-                {% empty %}
-                    <br>
-                    There are no more annotations to validate for this category!
-                {% endfor %}
-            </div>
-            {% if annotations_forms %}
-                <br><br>
-                <div class="field">
-                    {{ category_comment_form.comment }}
-                    <input id="id_category_id" name="category_id" type="hidden" value="{{ node.node_id }}">
-                    <input id="id_dataset" name="dataset" type="hidden" value="{{ dataset.id }}">
+        <div id="form_container" hidden>
+            <div class="ui grid">
+                <div class="ten wide column">
+                    <h2>Is <div class="ui big label">{{ node.name }}</div> present in the following sounds?</h2>
                 </div>
+                <div class="six wide column right aligned">
+                    {% if annotations_forms %}
+                        <a href="javascript:void(0);" onclick="$('#help_modal').modal('show');" class="ui orange button right labeled icon">Help <i class="help icon"></i></a>
+                        <a href="{% url 'contribute-validate-annotations-category' dataset.short_name main_node_data.url_id %}" class="ui button right labeled teal icon">Choose other sounds <i class="refresh icon"></i></a>
+                    {% endif %}
+                </div>
+            </div>
+            <br>
+            <form id="votes_form" class="ui form">{% csrf_token %}
+                {{ formset.management_form }}
+                <div class="ui centered cards">
+                    {% for annotation, form in annotations_forms %}
+                        <div class="card" id="row_annotation_{{ forloop.counter0 }}">
+                            {% with annotation.sound_dataset.sound.freesound_id as fsid  %}
+                                <div class="content">
+                                    <div class="right floated meta"><a href="javascript:void(0);" onclick="openFreesoundSoundPage('{{ fsid }}', '{{ forloop.counter0 }}');"><i class="external icon"></i></a></div>
+                                    <div class="header">#{{ forloop.counter }}</div>
+
+                                    <div class="description">
+                                        <div class="ui grid">
+                                            <div class="eight wide column">
+                                                {{ fsid| fs_embed | safe }}
+                                            </div>
+                                            <div class="eight wide column vote_card_form">
+                                                {{ form.vote }}
+                                                {{ form.annotation_id }}
+                                                {{ form.visited_sound }}
+                                            </div>
+                                        </div>
+
+                                    </div>
+                                </div>
+                            {% endwith %}
+                        </div>
+                    {% empty %}
+                        <br>
+                        There are no more annotations to validate for this category!
+                    {% endfor %}
+                </div>
+                {% if annotations_forms %}
+                    <br><br>
+                    <div class="field">
+                        {{ category_comment_form.comment }}
+                        <input id="id_category_id" name="category_id" type="hidden" value="{{ node.node_id }}">
+                        <input id="id_dataset" name="dataset" type="hidden" value="{{ dataset.id }}">
+                    </div>
+                {% endif %}
+            </form>
+            {% if annotations_forms %}
+                <br><button id="submitButton" class="right floated ui green button" onclick="submitForm();">Submit!</button>
             {% endif %}
-        </form>
-        {% if annotations_forms %}
-            <br><button id="submitButton" class="right floated ui green button" onclick="submitForm();">Submit!</button>
-        {% endif %}
+        </div>
     {% endif %}
+
 
     <!-- on success modal -->
     <div id="on_success_modal" class="ui basic modal">

--- a/datasets/templates/datasets/contribute_validate_annotations_category.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_category.html
@@ -71,7 +71,7 @@
                 <div class="six wide column right aligned">
                     {% if annotations_forms %}
                         <a href="javascript:void(0);" onclick="$('#help_modal').modal('show');" class="ui orange button right labeled icon">Help <i class="help icon"></i></a>
-                        <a href="{% url 'contribute-validate-annotations-category' dataset.short_name main_node_data.url_id %}?new_sounds=True" class="ui button right labeled teal icon">Choose other sounds <i class="refresh icon"></i></a>
+                        <a href="{% url 'contribute-validate-annotations-category' dataset.short_name main_node_data.url_id %}?{{skip_tempo_parameter}}=True" class="ui button right labeled teal icon">Choose other sounds <i class="refresh icon"></i></a>
                     {% endif %}
                 </div>
             </div>
@@ -135,7 +135,7 @@
             </p>
         </div>
         <div class="actions">
-            <a href="{% url 'contribute-validate-annotations-category' dataset.short_name main_node_data.url_id %}?new_sounds=True" class="green ui inverted right labeled button icon"><i class="plus icon"></i> Give me more sounds from this category</a>
+            <a href="{% url 'contribute-validate-annotations-category' dataset.short_name main_node_data.url_id %}?{{skip_tempo_parameter}}=True" class="green ui inverted right labeled button icon"><i class="plus icon"></i> Give me more sounds from this category</a>
             <a href="{% url 'choose_category' dataset.short_name %}" class="blue ui inverted button right labeled icon"><i class="refresh icon"></i> Choose another category</a>
         </div>
     </div>

--- a/datasets/templates/datasets/contribute_validate_annotations_category.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_category.html
@@ -33,9 +33,16 @@
         }
 
         function show_form() {
-            $('#start_annotating_button').hide();
+            $('#start_annotating_button_div').hide();
             $('#form_container').css("visibility", "visible");
         }
+
+        $( document ).ready(function() {
+            setTimeout(function(){
+                $('#start_annotating_button').removeClass('disabled');
+                $('#start_annotating_button_div').removeAttr("data-tooltip");
+            }, 10000);
+        });
     </script>
 {% endblock %}
 {% block content %}
@@ -52,8 +59,8 @@
     {% taxonomy_node_minimal_data dataset node.node_id as main_node_data %}
     <br>
     {% if not main_node_data.is_omitted %}
-        <div id="start_annotating_button" class="ui center aligned basic segment">
-            <button class="red ui button center" onclick="show_form();">Start annotating</button>
+        <div id="start_annotating_button_div" class="ui center aligned basic segment" data-tooltip="Take your time to look at the category and the related ones before starting to annotate...">
+            <button id="start_annotating_button" class="red ui button disabled" onclick="show_form();">Start annotating</button>
         </div>
         <div id="form_container" style="visibility: hidden">
             <div class="ui grid">

--- a/datasets/templates/datasets/contribute_validate_annotations_help.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_help.html
@@ -196,7 +196,7 @@
 
     <br><br>
     <div class="ui center aligned grid">
-        <a href="{% url 'contribute-validate-annotations' dataset.short_name %}" class="ui big right labeled icon blue button"><i class="checkmark box icon"></i>I can't wait anymore, let's start!</a>
+        <a href="{% url 'choose_category' dataset.short_name %}" class="ui big right labeled icon blue button"><i class="checkmark box icon"></i>I can't wait anymore, let's start!</a>
     </div>
 
 {% endblock %}

--- a/datasets/templates/datasets/contribute_validate_annotations_help.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_help.html
@@ -9,7 +9,7 @@
             $('#start_annotating_button_div').removeAttr("data-tooltip");
         }
         $(document).ready(function() {
-            setTimeout(function() {enable_button();}, 3000);
+            setTimeout(function() {enable_button();}, 20000);
             if ('{{skip_tempo}}'=='True'){enable_button();}
         });
     </script>

--- a/datasets/templates/datasets/contribute_validate_annotations_help.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_help.html
@@ -2,6 +2,18 @@
 {% load staticfiles %}
 {% load humanize %}
 {% block title %}Validate category annotations{% endblock title %}
+{% block page_js %}
+    <script type="text/javascript">
+        function enable_button() {
+            $('#start_annotating_button').removeClass('disabled');
+            $('#start_annotating_button_div').removeAttr("data-tooltip");
+        }
+        $(document).ready(function() {
+            setTimeout(function() {enable_button();}, 3000);
+            if ('{{skip_tempo}}'=='True'){enable_button();}
+        });
+    </script>
+{% endblock %}
 {% block content %}
     <h1 class="ui header">Task instructions</h1>
 
@@ -195,8 +207,8 @@
     </table>
 
     <br><br>
-    <div class="ui center aligned grid">
-        <a href="{% url 'choose_category' dataset.short_name %}" class="ui big right labeled icon blue button"><i class="checkmark box icon"></i>I can't wait anymore, let's start!</a>
+    <div id="start_annotating_button_div" class="ui center aligned grid" data-tooltip="Take your time to read the instructions carefully before starting...">
+        <a id="start_annotating_button" href="{% url 'choose_category' dataset.short_name %}" class="ui big right labeled icon blue button disabled"><i class="checkmark box icon"></i>I can't wait anymore, let's start!</a>
     </div>
 
 {% endblock %}

--- a/datasets/templates/datasets/taxonomy_node_mini_info.html
+++ b/datasets/templates/datasets/taxonomy_node_mini_info.html
@@ -14,7 +14,7 @@
                                     {% taxonomy_node_minimal_data dataset node_id as sub_node_data  %}
                                     <div class="item" style="margin-left:0px;margin-right:5px;">
                                         >
-                                        <a href="" target="_blank">{{ sub_node_data.name }}</a>
+                                        <a href="{% url 'dataset-explore-taxonomy-node' dataset.short_name sub_node_data.url_id %}" target="_blank">{{ sub_node_data.name }}</a>
                                     </div>
                                 {% endfor %}
                             </div>

--- a/datasets/templates/datasets/taxonomy_node_mini_info.html
+++ b/datasets/templates/datasets/taxonomy_node_mini_info.html
@@ -1,0 +1,44 @@
+{% load dataset_templatetags %}
+<table class="ui unstackable table" width="100%">
+    <tbody>
+            <td>Hierarchy</td>
+            <td>
+                <div class="ui list">
+                    {% for hierarchy_path in node.hierarchy_paths %}
+                        <div class="item">
+                            <div class="ui horizontal list">
+                                <div class="item">
+                                    <i class="tree icon"></i>
+                                </div>
+                                {% for node_id in hierarchy_path %}
+                                    {% taxonomy_node_minimal_data dataset node_id as sub_node_data  %}
+                                    <div class="item" style="margin-left:0px;margin-right:5px;">
+                                        >
+                                        <a href="" target="_blank">{{ sub_node_data.name }}</a>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    {% empty %}
+                        <div class="item">-</div>
+                    {% endfor %}
+                </div>
+            </td>
+        </tr>
+        <tr>
+            <td class="three wide">Description</td>
+            <td>{{ node.description }}</td>
+        </tr>
+        {% if node.freesound_examples %}
+            <tr><td>Examples</td>
+                <td>
+                    {% for fsid in node.freesound_examples %}
+                        {{ fsid| fs_embed | safe }}
+                    {% endfor %}
+                </td>
+            </tr>
+        {% endif %}
+                </div>
+            </div>
+    </tbody>
+</table>

--- a/datasets/templates/datasets/taxonomy_node_small_info.html
+++ b/datasets/templates/datasets/taxonomy_node_small_info.html
@@ -1,4 +1,15 @@
 {% load dataset_templatetags %}
+{% block page_js %}
+    <script type="text/javascript">
+    window.onload = function() {
+        $('.my-pop')
+          .popup({
+            on: 'click',
+          })
+        ;
+    };
+    </script>
+{% endblock %}
 <table class="ui unstackable table" width="100%">
     <tbody>
         <tr>
@@ -15,7 +26,7 @@
                                     {% taxonomy_node_minimal_data dataset node_id as sub_node_data  %}
                                     <div class="item" style="margin-left:0px;margin-right:5px;">
                                         >
-                                        <a href="{% url category_link_to dataset.short_name sub_node_data.url_id %}" target="_blank">{{ sub_node_data.name }}</a>
+                                        <a class="my-pop" data-html='{% display_taxonomy_node_mini_info dataset sub_node_data.node_id %}'>{{ sub_node_data.name }}</a>
                                     </div>
                                 {% endfor %}
                             </div>
@@ -33,7 +44,7 @@
                     {% for node_id in node.sibling_ids %}
                         {% taxonomy_node_minimal_data dataset node_id as sub_node_data %}
                         <div class="item" style="margin-left:0px;margin-right:5px;">
-                            <a href="{% url category_link_to dataset.short_name sub_node_data.url_id %}" target="_blank" class="ui label">{{ sub_node_data.name }}</a>
+                            <a class="my-pop ui label" data-html='{% display_taxonomy_node_mini_info dataset sub_node_data.node_id %}'>{{ sub_node_data.name }}</a>
                         </div>
                     {% endfor %}
                 </div></td>
@@ -46,7 +57,7 @@
                     {% for node_id in node.child_ids %}
                         {% taxonomy_node_minimal_data dataset node_id as sub_node_data %}
                         <div class="item" style="margin-left:0px;margin-right:5px;">
-                            <a href="{% url category_link_to dataset.short_name sub_node_data.url_id %}" target="_blank" class="ui label">{{ sub_node_data.name }}</a>
+                            <a class="my-pop ui label" data-html='{% display_taxonomy_node_mini_info dataset sub_node_data.node_id %}'>{{ sub_node_data.name }}</a>
                         </div>
                     {% endfor %}
                 </div></td>

--- a/datasets/templates/datasets/taxonomy_node_small_info.html
+++ b/datasets/templates/datasets/taxonomy_node_small_info.html
@@ -2,11 +2,13 @@
 {% block page_js %}
     <script type="text/javascript">
     $('.my-pop').ready(function() {
-        $('.my-pop')
-          .popup({
+        $('.my-pop').popup({
             on: 'click',
-          })
-        ;
+            closable: false,
+            onShow: function(){
+                $('.my-pop').popup('hide');
+            }
+        });
     });
     </script>
 {% endblock %}

--- a/datasets/templates/datasets/taxonomy_node_small_info.html
+++ b/datasets/templates/datasets/taxonomy_node_small_info.html
@@ -4,10 +4,10 @@
     $('.my-pop').ready(function() {
         $('.my-pop').popup({
             on: 'click',
-            closable: false,
-            onShow: function(){
-                $('.my-pop').popup('hide');
-            }
+            <!--closable: false,-->
+            <!--onShow: function(){-->
+                <!--$('.my-pop').popup('hide');-->
+            <!--}-->
         });
     });
     </script>

--- a/datasets/templates/datasets/taxonomy_node_small_info.html
+++ b/datasets/templates/datasets/taxonomy_node_small_info.html
@@ -26,6 +26,19 @@
                 </div>
             </td>
         </tr>
+        {% if node.sibling_ids %}
+            <tr>
+                <td>Siblings</td>
+                <td><div class="ui horizontal list">
+                    {% for node_id in node.sibling_ids %}
+                        {% taxonomy_node_minimal_data dataset node_id as sub_node_data %}
+                        <div class="item" style="margin-left:0px;margin-right:5px;">
+                            <a href="{% url category_link_to dataset.short_name sub_node_data.url_id %}" target="_blank" class="ui label">{{ sub_node_data.name }}</a>
+                        </div>
+                    {% endfor %}
+                </div></td>
+            </tr>
+        {% endif %}
         {% if node.child_ids %}
             <tr>
                 <td>Direct children</td>

--- a/datasets/templates/datasets/taxonomy_node_small_info.html
+++ b/datasets/templates/datasets/taxonomy_node_small_info.html
@@ -1,0 +1,89 @@
+{% load dataset_templatetags %}
+<table class="ui unstackable table" width="100%">
+    <tbody>
+        <tr>
+            <td>Hierarchy</td>
+            <td>
+                <div class="ui list">
+                    {% for hierarchy_path in node.hierarchy_paths %}
+                        <div class="item">
+                            <div class="ui horizontal list">
+                                <div class="item">
+                                    <i class="tree icon"></i>
+                                </div>
+                                {% for node_id in hierarchy_path %}
+                                    {% taxonomy_node_minimal_data dataset node_id as sub_node_data  %}
+                                    <div class="item" style="margin-left:0px;margin-right:5px;">
+                                        >
+                                        <a href="{% url category_link_to dataset.short_name sub_node_data.url_id %}" target="_blank">{{ sub_node_data.name }}</a>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    {% empty %}
+                        <div class="item">-</div>
+                    {% endfor %}
+                </div>
+            </td>
+        </tr>
+        {% if node.child_ids %}
+            <tr>
+                <td>Direct children</td>
+                <td><div class="ui horizontal list">
+                    {% for node_id in node.child_ids %}
+                        {% taxonomy_node_minimal_data dataset node_id as sub_node_data %}
+                        <div class="item" style="margin-left:0px;margin-right:5px;">
+                            <a href="{% url category_link_to dataset.short_name sub_node_data.url_id %}" target="_blank" class="ui label">{{ sub_node_data.name }}</a>
+                        </div>
+                    {% endfor %}
+                </div></td>
+            </tr>
+        {% endif %}
+        <tr>
+            <td class="three wide">Description</td>
+            <td>{{ node.description }}</td>
+        </tr>
+        {% if node.freesound_examples %}
+            <tr><td>Examples</td>
+                <td>
+                    {% for fsid in node.freesound_examples %}
+                        {{ fsid| fs_embed | safe }}
+                    {% endfor %}
+                </td>
+            </tr>
+        {% endif %}
+        {% if user_is_maintainer %}
+            {% if node.comments %}
+                <tr>
+                    <td>User comments</td><td>
+                    <div class="ui segments">
+                        {% for comment in node.comments %}
+                            <div class="ui segment">{{ comment.comment | linebreaksbr }}</div>
+                        {% endfor %}
+                    </div>
+                    </td>
+                </tr>
+            {% endif %}
+            {% if node.votes_stats %}
+                <tr><td colspan="2" style="padding:0;">
+                    <div class="category_quality_bars" style="text-align: center">
+                        <div class="element" style="width:{{ node.votes_stats.percentage_present_and_predominant|floatformat:2 }}%;background-color:#21ba45;" data-tooltip="Present and predominant">
+                            {{ node.votes_stats.percentage_present_and_predominant|floatformat:2 }}{% if node.votes_stats.num_present_and_predominant %}%{% endif %}
+                        </div><div class="element" style="width:{{ node.votes_stats.percentage_present_not_predominant|floatformat:2 }}%;background-color:#b5cc18;" data-tooltip="Present but not predominant">
+                            {{ node.votes_stats.percentage_present_not_predominant|floatformat:2 }}{% if node.votes_stats.num_present_not_predominant %}%{% endif %}
+                        </div><div class="element" style="width:{{ node.votes_stats.percentage_unsure|floatformat:2 }}%;background-color:#eaae00;" data-tooltip="Unsure">
+                            {{ node.votes_stats.percentage_unsure|floatformat:2 }}{% if node.votes_stats.num_unsure %}%{% endif %}
+                        </div><div class="element" style="width:{{ node.votes_stats.percentage_not_present|floatformat:2 }}%;background-color:#f26202;" data-tooltip="Not present">
+                            {{ node.votes_stats.percentage_not_present|floatformat:2 }}{% if node.votes_stats.num_not_present %}%{% endif %}
+                        </div>
+                    </div>
+                </td></tr>
+            {% endif %}
+        {% endif %}
+        {% if node.is_omitted %}
+            <tr class="negative">
+                <td colspan="2">This node is labeled as <b>omitted</b> and its annotations should not be validated</td>
+            </tr>
+        {% endif %}
+    </tbody>
+</table>

--- a/datasets/templates/datasets/taxonomy_node_small_info.html
+++ b/datasets/templates/datasets/taxonomy_node_small_info.html
@@ -1,13 +1,13 @@
 {% load dataset_templatetags %}
 {% block page_js %}
     <script type="text/javascript">
-    window.onload = function() {
+    $('.my-pop').ready(function() {
         $('.my-pop')
           .popup({
             on: 'click',
           })
         ;
-    };
+    });
     </script>
 {% endblock %}
 <table class="ui unstackable table" width="100%">

--- a/datasets/templatetags/dataset_templatetags.py
+++ b/datasets/templatetags/dataset_templatetags.py
@@ -95,6 +95,12 @@ def display_taxonomy_node_info(context, dataset, node_id, category_link_to='e'):
             'user_is_maintainer': user_is_maintainer}
 
 
+@register.inclusion_tag('datasets/taxonomy_node_mini_info.html')
+def display_taxonomy_node_mini_info(dataset, node_id):
+    node_data = taxonomy_node_data(dataset, node_id)
+    return {'dataset': dataset, 'node': node_data}
+
+
 @register.simple_tag(takes_context=False)
 def sounds_per_taxonomy_node(dataset, node_id, N):
     return dataset.sounds_per_taxonomy_node(node_id)[0:N]

--- a/datasets/templatetags/dataset_templatetags.py
+++ b/datasets/templatetags/dataset_templatetags.py
@@ -97,8 +97,10 @@ def display_taxonomy_node_info(context, dataset, node_id, category_link_to='e'):
 
 @register.inclusion_tag('datasets/taxonomy_node_mini_info.html')
 def display_taxonomy_node_mini_info(dataset, node_id):
-    node_data = taxonomy_node_data(dataset, node_id)
-    return {'dataset': dataset, 'node': node_data}
+    node = dataset.taxonomy.get_element_at_id(node_id).as_dict()
+    hierarchy_paths = dataset.taxonomy.get_hierarchy_paths(node['node_id'])
+    node['hierarchy_paths'] = hierarchy_paths if hierarchy_paths is not None else []
+    return {'dataset': dataset, 'node': node}
 
 
 @register.simple_tag(takes_context=False)

--- a/datasets/templatetags/dataset_templatetags.py
+++ b/datasets/templatetags/dataset_templatetags.py
@@ -83,7 +83,7 @@ def taxonomy_node_minimal_data(dataset, node_id):
     return node
 
 
-@register.inclusion_tag('datasets/taxonomy_node_info.html', takes_context=True)
+@register.inclusion_tag('datasets/taxonomy_node_small_info.html', takes_context=True)
 def display_taxonomy_node_info(context, dataset, node_id, category_link_to='e'):
     user_is_maintainer = dataset.user_is_maintainer(context['request'].user)
     category_link_to = {

--- a/datasets/views.py
+++ b/datasets/views.py
@@ -135,7 +135,10 @@ def contribute(request, short_name):
 def contribute_validate_annotations(request, short_name):
     dataset = get_object_or_404(Dataset, short_name=short_name)
     if request.GET.get('help', False):
-        return render(request, 'datasets/contribute_validate_annotations_help.html', {'dataset': dataset})
+        if request.session.get('read_instructions', False) or request.user.profile.contributed_two_weeks_ago:
+            return render(request, 'datasets/contribute_validate_annotations_help.html', {'dataset': dataset, 'skip_tempo': True})
+        else:
+            return render(request, 'datasets/contribute_validate_annotations_help.html', {'dataset': dataset, 'skip_tempo': False})
     if not request.user.is_authenticated():
         return HttpResponseRedirect(reverse('login') + '?next={0}'.format(
             reverse('contribute-validate-annotations', args=[dataset.short_name])))
@@ -320,6 +323,7 @@ def save_contribute_validate_annotations_category(request):
 @login_required
 def choose_category(request, short_name):
     dataset = get_object_or_404(Dataset, short_name=short_name)
+    request.session['read_instructions'] = True
     return render(request, 'datasets/dataset_taxonomy_choose_category.html', {'dataset': dataset})
 
 

--- a/datasets/views.py
+++ b/datasets/views.py
@@ -154,7 +154,7 @@ def contribute_validate_annotations_category(request, short_name, node_id):
     node_id = unquote(node_id)
     node = dataset.taxonomy.get_element_at_id(node_id)
     skip_tempo = True if user_last_category == node and user.profile.contributed_recently or \
-                         request.GET.get('new_sounds', False) else False
+                         request.GET.get(settings.SKIP_TEMPO_PARAMETER, False) else False
 
     annotation_ids = []
     # check if user annotate a new category or has not annotate for a long time
@@ -228,7 +228,8 @@ def contribute_validate_annotations_category(request, short_name, node_id):
     return render(request, 'datasets/contribute_validate_annotations_category.html',
                   {'dataset': dataset, 'node': node, 'annotations_forms': annotations_forms,
                    'formset': formset, 'N': N, 'user_is_maintainer': user_is_maintainer,
-                   'category_comment_form': category_comment_form, 'skip_tempo': skip_tempo})
+                   'category_comment_form': category_comment_form, 'skip_tempo': skip_tempo,
+                   'skip_tempo_parameter': settings.SKIP_TEMPO_PARAMETER})
 
 
 @login_required

--- a/datasets/views.py
+++ b/datasets/views.py
@@ -153,6 +153,8 @@ def contribute_validate_annotations_category(request, short_name, node_id):
     user_last_category = user.profile.last_category_annotated
     node_id = unquote(node_id)
     node = dataset.taxonomy.get_element_at_id(node_id)
+    skip_tempo = True if user_last_category == node and user.profile.contributed_recently or \
+                         request.GET.get('new_sounds', False) else False
 
     annotation_ids = []
     # check if user annotate a new category or has not annotate for a long time
@@ -226,7 +228,7 @@ def contribute_validate_annotations_category(request, short_name, node_id):
     return render(request, 'datasets/contribute_validate_annotations_category.html',
                   {'dataset': dataset, 'node': node, 'annotations_forms': annotations_forms,
                    'formset': formset, 'N': N, 'user_is_maintainer': user_is_maintainer,
-                   'category_comment_form': category_comment_form})
+                   'category_comment_form': category_comment_form, 'skip_tempo': skip_tempo})
 
 
 @login_required

--- a/freesound_datasets/settings.py
+++ b/freesound_datasets/settings.py
@@ -207,7 +207,7 @@ LOGGING = {
 }
 
 # Parameter strings
-SKIP_TEMPO_PARAMETER = 'n'
+SKIP_TEMPO_PARAMETER = 'skt'
 
 # Import local settings
 from freesound_datasets.local_settings import *

--- a/freesound_datasets/settings.py
+++ b/freesound_datasets/settings.py
@@ -206,5 +206,8 @@ LOGGING = {
     },
 }
 
+# Parameter strings
+SKIP_TEMPO_PARAMETER = 'n'
+
 # Import local settings
 from freesound_datasets.local_settings import *

--- a/static/css/popupUi.css
+++ b/static/css/popupUi.css
@@ -1,0 +1,3 @@
+.ui.popup {
+    max-width: 900px;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,7 +16,8 @@
     <script src="{% static "js/dataTables.semanticui.min.js" %}" type="text/javascript"></script>
     <script src="{% static "semanticui/semantic.min.js" %}" type="text/javascript"></script>
     <script src="{% static "js/main.js" %}" type="text/javascript"></script>
-    <script src="{% static "js/d3.v3.min.js" %}"></script> 
+    <script src="{% static "js/d3.v3.min.js" %}"></script>
+    <link rel="stylesheet" type="text/css" href="{% static "css/popupUi.css" %}" />
     {% block extra_head %}
     {% endblock extra_head%}
 </head>


### PR DESCRIPTION
#71 

- Add _sibling_ categories in category table of validate category annotations form page
- Put instructions after selecting the _validate category annotations_ task
- Add pop-up informations (path, description, examples) in the explicit training phase for each category appearing in: _path_, _siblings_, _children_
- Hide vote form in validate category annotations form page, Add _start_ button for showing the vote form
- Add temporizing for enabling instructions and explicit training _start_ button
  - for instructions (20 sec), disable temporizing if user contributed 2 weeks ago, or read the instructions in his current session
  - for explicit training phase (10 sec), disable temporizing and show directly vote form if asking for new sounds