### PR TITLE
Change popup category mini info to Ajax

### DIFF
--- a/datasets/templates/datasets/taxonomy_node_small_info.html
+++ b/datasets/templates/datasets/taxonomy_node_small_info.html
@@ -1,13 +1,27 @@
 {% load dataset_templatetags %}
 {% block page_js %}
     <script type="text/javascript">
+    var popupLoading = '<div class="ui loading segment">Loading</div>';
     $('.my-pop').ready(function() {
         $('.my-pop').popup({
             on: 'click',
-            <!--closable: false,-->
-            <!--onShow: function(){-->
-                <!--$('.my-pop').popup('hide');-->
-            <!--}-->
+            html: popupLoading,
+            onShow: function(el){
+                var ajax_done = el.getAttribute('ajax_done')
+                if (ajax_done == 0) {
+                    var popup = this
+                    var ajax_url = el.getAttribute('ajax_url')
+                    $.ajax({
+                        url: ajax_url
+                    }).done(function(result) {
+                        popup.html(result);
+                        el.setAttribute("data-html", result);
+                        el.setAttribute("ajax_done", 1);
+                    }).fail(function() {
+                        popup.html('error')
+                    });
+                }
+            }
         });
     });
     </script>
@@ -28,7 +42,7 @@
                                     {% taxonomy_node_minimal_data dataset node_id as sub_node_data  %}
                                     <div class="item" style="margin-left:0px;margin-right:5px;">
                                         >
-                                        <a class="my-pop" data-html='{% display_taxonomy_node_mini_info dataset sub_node_data.node_id %}'>{{ sub_node_data.name }}</a>
+                                        <a class="my-pop" data-html='' ajax_done=0 ajax_url="{% url 'get-mini-node-info' dataset.short_name sub_node_data.url_id %}">{{ sub_node_data.name }}</a>
                                     </div>
                                 {% endfor %}
                             </div>
@@ -46,7 +60,7 @@
                     {% for node_id in node.sibling_ids %}
                         {% taxonomy_node_minimal_data dataset node_id as sub_node_data %}
                         <div class="item" style="margin-left:0px;margin-right:5px;">
-                            <a class="my-pop ui label" data-html='{% display_taxonomy_node_mini_info dataset sub_node_data.node_id %}'>{{ sub_node_data.name }}</a>
+                            <a class="my-pop ui label" data-html='' ajax_done=0 ajax_url = "{% url 'get-mini-node-info' dataset.short_name sub_node_data.url_id %}">{{ sub_node_data.name }}</a>
                         </div>
                     {% endfor %}
                 </div></td>
@@ -59,7 +73,7 @@
                     {% for node_id in node.child_ids %}
                         {% taxonomy_node_minimal_data dataset node_id as sub_node_data %}
                         <div class="item" style="margin-left:0px;margin-right:5px;">
-                            <a class="my-pop ui label" data-html='{% display_taxonomy_node_mini_info dataset sub_node_data.node_id %}'>{{ sub_node_data.name }}</a>
+                            <a class="my-pop ui label" data-html='' ajax_done=0 ajax_url = "{% url 'get-mini-node-info' dataset.short_name sub_node_data.url_id %}">{{ sub_node_data.name }}</a>
                         </div>
                     {% endfor %}
                 </div></td>

--- a/datasets/urls.py
+++ b/datasets/urls.py
@@ -24,4 +24,5 @@ urlpatterns = [
     url(r'^(?P<short_name>[^\/]+)/contribute/choose_category/$', choose_category, name='choose_category'),
     url(r'^(?P<short_name>[^\/]+)/contribute/choose_category_table/$', dataset_taxonomy_table_choose,
         name='dataset_taxonomy_table_choose'),
+    url(r'^(?P<short_name>[^\/]+)/mini-node-info/(?P<node_id>[^\/]+)/$', get_mini_node_info, name='get-mini-node-info'),
 ]

--- a/datasets/views.py
+++ b/datasets/views.py
@@ -366,6 +366,15 @@ def dataset_taxonomy_table_choose(request, short_name):
         'dataset': dataset, 'end_of_table': end_of_table, 'hierarchy_paths': hierarchy_paths, 'nodes': nodes})
 
 
+def get_mini_node_info(request, short_name, node_id):
+    node_id = unquote(node_id)
+    dataset = get_object_or_404(Dataset, short_name=short_name)
+    node = dataset.taxonomy.get_element_at_id(node_id).as_dict()
+    hierarchy_paths = dataset.taxonomy.get_hierarchy_paths(node['node_id'])
+    node['hierarchy_paths'] = hierarchy_paths if hierarchy_paths is not None else []
+    return render(request, 'datasets/taxonomy_node_mini_info.html', {'dataset': dataset, 'node': node})
+
+
 ########################
 # DOWNLOAD DATASET VIEWS
 ########################


### PR DESCRIPTION
Loading all the _taxonomy_node_mini_info_ takes time and makes unnecessary queries.
Data is requested when a user clicks on a category for showing the popup with the category information.