### PR TITLE
Add feedback number of annotation pages - Iss97

### DIFF
--- a/datasets/models.py
+++ b/datasets/models.py
@@ -554,7 +554,7 @@ class Profile(models.Model):
     # this store the last category the user contributed to
 
     def refresh_countdown(self):
-        self.countdown_trustable = 5
+        self.countdown_trustable = 3
         self.save()
 
     @property

--- a/datasets/templates/datasets/contribute_validate_annotations_category.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_category.html
@@ -50,6 +50,7 @@
             }, 10000);
             if ('{{skip_tempo}}'=='True'){show_form();}
         });
+        var nb_task1_pages = {{nb_task1_pages}}
     </script>
 {% endblock %}
 {% block content %}

--- a/datasets/templates/datasets/contribute_validate_annotations_category.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_category.html
@@ -185,13 +185,16 @@
         </div>
         <div class="content">
             <p>
-                Congratulations, you just annotated <b>{{ N }} sounds</b>!
-                What do you want to do next?
+                Congratulations, you just annotated {{ N }} sounds! <br>
+                You annotated <b>{{ nb_task1_pages }}/6 pages</b>.
             </p>
         </div>
         <div class="actions">
-            <a href="{% url 'contribute-validate-annotations-category' dataset.short_name node.url_id %}?{{skip_tempo_parameter}}=True" class="green ui inverted right labeled button icon"><i class="plus icon"></i> Give me more sounds from this category</a>
-            <a href="{% url 'choose_category' dataset.short_name %}" class="blue ui inverted button right labeled icon"><i class="refresh icon"></i> Choose another category</a>
+            {% if nb_task1_pages < 6 %}
+                <a href="{% url 'contribute-validate-annotations-category' dataset.short_name node.url_id %}?{{skip_tempo_parameter}}=True" class="green ui inverted right labeled button icon"><i class="plus icon"></i> Give me more sounds from this category</a>
+            {% else %}
+                <a href="{% url 'choose_category' dataset.short_name %}" class="blue ui inverted button right labeled icon"><i class="refresh icon"></i> Choose another category</a>
+            {% endif %}
         </div>
     </div>
     <!-- end on success modal -->

--- a/datasets/templates/datasets/contribute_validate_annotations_category.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_category.html
@@ -186,15 +186,21 @@
         <div class="content">
             <p>
                 Congratulations, you just annotated {{ N }} sounds! <br>
-                You annotated <b>{{ nb_task1_pages }}/6 pages</b>.
+                {% if nb_task1_pages < 6 %}
+                    You annotated <b>{{ nb_task1_pages }}/6 pages</b>.
+                {% else %}
+                    Thank you very much, you annotated {{ nb_task1_pages }}/6 pages.
+                    You can choose another category or take a deserved rest!
+                {% endif %}
             </p>
         </div>
         <div class="actions">
             {% if nb_task1_pages < 6 %}
                 <a href="{% url 'contribute-validate-annotations-category' dataset.short_name node.url_id %}?{{skip_tempo_parameter}}=True" class="green ui inverted right labeled button icon"><i class="plus icon"></i> Give me more sounds from this category</a>
             {% else %}
-                <a href="{% url 'choose_category' dataset.short_name %}" class="blue ui inverted button right labeled icon"><i class="refresh icon"></i> Choose another category</a>
+                <a href="{% url 'choose_category' dataset.short_name %}" class="green ui inverted button right labeled icon"><i class="refresh icon"></i> Choose another category</a>
             {% endif %}
+            <a href="{% url 'dataset' dataset.short_name %}" class="blue ui inverted button right labeled icon"><i class="home icon"></i> Go back to the dataset page</a>
         </div>
     </div>
     <!-- end on success modal -->

--- a/datasets/views.py
+++ b/datasets/views.py
@@ -245,8 +245,8 @@ def contribute_validate_annotations_category(request, short_name, node_id):
 
     nb_task1_pages = request.session.get('nb_task1_pages', False)
     if not nb_task1_pages:
-        request.session['nb_task1_pages'] = 0
-        nb_task1_pages = 0
+        request.session['nb_task1_pages'] = 1
+        nb_task1_pages = 1
 
     return render(request, 'datasets/contribute_validate_annotations_category.html',
                   {'dataset': dataset, 'node': node, 'annotations_forms': annotations_forms,
@@ -348,6 +348,7 @@ def save_contribute_validate_annotations_category(request):
 def choose_category(request, short_name):
     dataset = get_object_or_404(Dataset, short_name=short_name)
     request.session['read_instructions'] = True
+    request.session['nb_task1_pages'] = 0
     return render(request, 'datasets/dataset_taxonomy_choose_category.html', {'dataset': dataset})
 
 
@@ -386,7 +387,6 @@ def dataset_taxonomy_table_choose(request, short_name):
         end_of_table = True
         nodes = dataset.get_categories_to_validate(request.user).exclude(omitted=True).order_by('nb_ground_truth')[:20]
 
-    request.session['nb_task1_pages'] = 0
     return render(request, 'datasets/dataset_taxonomy_table_choose.html', {
         'dataset': dataset, 'end_of_table': end_of_table, 'hierarchy_paths': hierarchy_paths, 'nodes': nodes})
 

--- a/datasets/views.py
+++ b/datasets/views.py
@@ -243,11 +243,17 @@ def contribute_validate_annotations_category(request, short_name, node_id):
 
     category_comment_form = CategoryCommentForm()
 
+    nb_task1_pages = request.session.get('nb_task1_pages', False)
+    if not nb_task1_pages:
+        request.session['nb_task1_pages'] = 0
+        nb_task1_pages = 0
+
     return render(request, 'datasets/contribute_validate_annotations_category.html',
                   {'dataset': dataset, 'node': node, 'annotations_forms': annotations_forms,
                    'formset': formset, 'N': N, 'user_is_maintainer': user_is_maintainer,
                    'category_comment_form': category_comment_form, 'skip_tempo': skip_tempo,
-                   'skip_tempo_parameter': settings.SKIP_TEMPO_PARAMETER})
+                   'skip_tempo_parameter': settings.SKIP_TEMPO_PARAMETER,
+                   'nb_task1_pages': nb_task1_pages})
 
 
 @login_required
@@ -330,6 +336,8 @@ def save_contribute_validate_annotations_category(request):
                 comment = comment_form.save(commit=False)
                 comment.created_by = request.user
                 comment.save()
+
+            request.session['nb_task1_pages'] += 1
         else:
             error_response = {'errors': [count for count, value in enumerate(formset.errors) if value != {}]}
             return JsonResponse(error_response)
@@ -378,6 +386,7 @@ def dataset_taxonomy_table_choose(request, short_name):
         end_of_table = True
         nodes = dataset.get_categories_to_validate(request.user).exclude(omitted=True).order_by('nb_ground_truth')[:20]
 
+    request.session['nb_task1_pages'] = 0
     return render(request, 'datasets/dataset_taxonomy_table_choose.html', {
         'dataset': dataset, 'end_of_table': end_of_table, 'hierarchy_paths': hierarchy_paths, 'nodes': nodes})
 

--- a/datasets/views.py
+++ b/datasets/views.py
@@ -306,6 +306,7 @@ def save_contribute_validate_annotations_category(request):
                 elif positive_test is False or negative_test is False:  # one of the test failed
                     request.user.profile.test = 'FA'
                 request.user.profile.refresh_countdown()
+                request.user.profile.countdown_trustable -= 1
 
             else:  # user passed the test: check the countdown and decrement it if needed
                 if request.user.profile.countdown_trustable < 2:  # user test is now in failed state


### PR DESCRIPTION
#97 
We decided to:
- Add QC test sounds in the first page, and if passed, keep the test result for 3 pages. If not passed, tests are added until the user succeed.
- Do sessions of 6 pages


The modal that pops after submitting proposes to:
- Give more sounds from the same category or go back to the dataset explore page (if 6 pages is not reached)
- Choose another category or go back to the dataset explore page (if 6 pages is reached)