### PR TITLE
Add vote numbers taxonomy node table

### DIFF
--- a/datasets/models.py
+++ b/datasets/models.py
@@ -560,6 +560,30 @@ class CandidateAnnotation(models.Model):
         else:
             return None
 
+    @property
+    def freesound_id(self):
+        return self.sound_dataset.sound.freesound_id
+
+    def num_vote_value(self, value):
+        vote_values = [v.vote for v in self.votes.all() if v.test is not 'FA']
+        return vote_values.count(value)
+
+    @property
+    def num_PP(self):
+        return self.num_vote_value(1)
+
+    @property
+    def num_PNP(self):
+        return self.num_vote_value(0.5)
+
+    @property
+    def num_U(self):
+        return self.num_vote_value(0)
+
+    @property
+    def num_NP(self):
+        return self.num_vote_value(-1)
+
 
 class GroundTruthAnnotation(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)

--- a/datasets/templates/datasets/taxonomy_node.html
+++ b/datasets/templates/datasets/taxonomy_node.html
@@ -21,6 +21,10 @@
             <tr>
                 <th>Sound</th>
                 <th>Freesound URL</th>
+                <th><div data-tooltip="Number of times validated as present and predominant"># PP</div></th>
+                <th><div data-tooltip="Number of times validated as present but not predominant"># PNP</div></th>
+                <th><div data-tooltip="Number of times validated as not present"># NP</div></th>
+                <th><div data-tooltip="Number of times validated as unsure"># U</div></th>
             </tr>
         </thead>
         <tbody>
@@ -28,6 +32,10 @@
                 <tr>
                     <td>{{ sound.freesound_id | fs_embed | safe }}</td>
                     <td><a href="http://freesound.org/s/{{ sound.freesound_id }}" target="_blank">http://freesound.org/s/{{ sound.freesound_id }}</a></td>
+                    <td>{{ sound.num_PP }}</td>
+                    <td>{{ sound.num_PNP }}</td>
+                    <td>{{ sound.num_NP }}</td>
+                    <td>{{ sound.num_U }}</td>
                 </tr>
             {% endfor %} 
         </tbody>

--- a/datasets/views.py
+++ b/datasets/views.py
@@ -105,20 +105,22 @@ def taxonomy_node(request, short_name, node_id):
     user_is_maintainer = dataset.user_is_maintainer(request.user)
     node_id = unquote(node_id)
     node = dataset.taxonomy.get_element_at_id(node_id)
-    sound_list = dataset.sounds_per_taxonomy_node(node_id)
-    paginator = Paginator(sound_list, 10)
+    annotation_list = dataset.annotations_per_taxonomy_node(node_id)\
+        .annotate(num_votes=Count('votes')).order_by('-num_votes')
+    paginator = Paginator(annotation_list, 10)
     page = request.GET.get('page')
     try:
-        sounds = paginator.page(page)
+        annotations = paginator.page(page)
     except PageNotAnInteger:
         # If page is not an integer, deliver first page.
-        sounds = paginator.page(1)
+        annotations = paginator.page(1)
     except EmptyPage:
         # If page is out of range (e.g. 9999), deliver last page of results.
-        sounds = paginator.page(paginator.num_pages)
+        annotations = paginator.page(paginator.num_pages)
         
-    return render(request, 'datasets/taxonomy_node.html', {'dataset': dataset, 'node': node, 'sounds': sounds,
-                                                           'user_is_maintainer': user_is_maintainer})
+    return render(request, 'datasets/taxonomy_node.html', {'dataset': dataset, 'node': node,
+                                                           'user_is_maintainer': user_is_maintainer,
+                                                           'sounds': annotations})
 
 
 #############################


### PR DESCRIPTION
#110 
#111 

The type and number of votes for each category table has been added.

The sorting is not trivial, some SQL queries should be done for allowing a complex sorting as proposed in #111. For now, the sounds are sorted using the number of votes. First the one with more votes.