### PR TITLE
Show goal status for each category - Iss136

### DIFF
--- a/datasets/templates/datasets/dataset_explore.html
+++ b/datasets/templates/datasets/dataset_explore.html
@@ -36,6 +36,12 @@
                 $('#dataset_contents').DataTable({
                     'paging': true,
                     'info': true,
+                    'columns': [
+                        null,
+                        { "width": "70px" },
+                        { "width": "170px" },
+                        { "width": "100px" },
+                    ]
                 });
                 $('#dataset_contents_paginate').parent().attr('style', 'width: 100% !important');
             });

--- a/datasets/templates/datasets/dataset_taxonomy_choose_category.html
+++ b/datasets/templates/datasets/dataset_taxonomy_choose_category.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% load staticfiles %}
 {% load humanize %}
+{% block extra_head %}
+    <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
+{% endblock %}
 {% block title %}Validate category annotations{% endblock title %}
 {% block page_js %}
     <script type="text/javascript">
@@ -8,7 +11,9 @@
             loadDatasetTaxonomyTableChoose(0);
             loadDatasetTaxonomyTablePriority();
             loadDatasetTaxonomyTableSearch();
-            $('.menu .item').tab();
+            $('.menu .item').tab({
+                'onVisible': function(){$(window).resize();}  // FIXES BUG: set search table column width
+            });
         });
         function addPopUpEvent(targets) {
             var popupLoading = '<div style="height:180px; width:500px" class="ui loading segment">Loading</div>';
@@ -72,7 +77,12 @@
                 $('#dataset_contents').DataTable({
                     'paging': true,
                     'info': true,
-                    'ordering': false
+                    'ordering': true,
+                    'columns': [
+                        null,
+                        { "width": "220px" },
+                        { "width": "120px" },
+                    ]
                 });
                 $('#dataset_contents_paginate').parent().attr('style', 'width: 100% !important');
                 $('#dataset_contents').on('draw.dt', function () {
@@ -138,7 +148,7 @@
               <div style="margin-left:25px;"><i class="flag outline checkered icon big white"></i></div>
               <div style="margin-right:15px;"><p>Choose a category among <b>our priorities</b> for the creation of FSD</p></div>
           </a>
-          <a class="item" data-tab="third">
+          <a class="item" data-tab="third" id="search_table_tab">
               <div style="margin-left:25px;margin-right:25px;"><i class="search icon big white"></i></div>
               <div style="margin-right:15px;"><p><b>Search</b> a category by its name</p></div>
           </a>

--- a/datasets/templates/datasets/dataset_taxonomy_table.html
+++ b/datasets/templates/datasets/dataset_taxonomy_table.html
@@ -7,11 +7,9 @@
     <thead>
         <tr>
             <th>Category</th>
-            <!--<th><div data-tooltip="Audio samples which are candidate annotations for this category">-->
             <th><div data-tooltip="Audio samples with candidate annotations for this category">
-            <!--<th><div data-tooltip="Candidate audio sample for this category">-->
                 # audio samples</div></th>
-            <th><div data-tooltip="Candidate annotations validated by more than one user. The progress bar indicates how close we are from reaching our first goal (100 ground truth in each category)">
+            <th><div data-tooltip="Candidate annotations validated by more than one user, with majority agreement on the presence of a sound category in an audio sample">
             # ground truth</div></th>
             <th></th>
         </tr>
@@ -22,9 +20,7 @@
             <td>{{ node.name }}</td>
             <td>{{ node.num_sounds }}</td>
             <td>
-                <div class="w3-light-grey w3-round" style="width: 150px;" >
-                   <div class="w3-container w3-round w3-blue" style="width:{{ node.num_ground_truth|percent_goal }}%; text-align: center; padding-left:0px; padding-right:0px; min-width:15%;">{{ node.num_ground_truth }}</div>
-                </div>
+                {% goal_progress_bar node.num_ground_truth %}
             </td>
             <td class="right aligned"><a href="{% url category_link_to.0 dataset.short_name node.url_id %}" class="blue ui button right labeled icon">{{ category_link_to.1 }} <i class="right arrow icon"></i></a></td>
         </tr>

--- a/datasets/templates/datasets/dataset_taxonomy_table.html
+++ b/datasets/templates/datasets/dataset_taxonomy_table.html
@@ -1,4 +1,8 @@
 {% load general_templatetags %}
+{% load dataset_templatetags %}
+{% block extra_head %}
+    <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
+{% endblock %}
 <table id="dataset_contents" class="ui unstackable table" width="100%" style="margin-bottom:5px;">
     <thead>
         <tr>
@@ -17,7 +21,11 @@
         <tr {% if node.is_omitted %}class="negative"{% endif %}>
             <td>{{ node.name }}</td>
             <td>{{ node.num_sounds }}</td>
-            <td>{{ node.num_ground_truth }}</td>
+            <td>
+                <div class="w3-light-grey w3-round" style="width: 150px;" >
+                   <div class="w3-container w3-round w3-blue" style="width:{{ node.num_ground_truth|percent_goal }}%; text-align: center; padding-left:0px; padding-right:0px; min-width:15%;">{{ node.num_ground_truth }}</div>
+                </div>
+            </td>
             <td class="right aligned"><a href="{% url category_link_to.0 dataset.short_name node.url_id %}" class="blue ui button right labeled icon">{{ category_link_to.1 }} <i class="right arrow icon"></i></a></td>
         </tr>
     {% endfor %}

--- a/datasets/templates/datasets/dataset_taxonomy_table.html
+++ b/datasets/templates/datasets/dataset_taxonomy_table.html
@@ -11,7 +11,7 @@
             <th><div data-tooltip="Audio samples with candidate annotations for this category">
             <!--<th><div data-tooltip="Candidate audio sample for this category">-->
                 # audio samples</div></th>
-            <th><div data-tooltip="Candidate annotations validated by more than one user, with majority agreement on the presence of a sound category in an audio sample">
+            <th><div data-tooltip="Candidate annotations validated by more than one user. The progress bar indicates how close we are from reaching our first goal (100 ground truth in each category)">
             # ground truth</div></th>
             <th></th>
         </tr>

--- a/datasets/templates/datasets/dataset_taxonomy_table_choose.html
+++ b/datasets/templates/datasets/dataset_taxonomy_table_choose.html
@@ -35,6 +35,7 @@
         <thead>
             <tr>
                 <th>Category</th>
+                <th><div data-tooltip="Indicates how close we are from reaching our first goal (100 ground truth in each category)">Goal</div></th>
                 <th></th>
             </tr>
         </thead>
@@ -62,6 +63,11 @@
                               ajax_url="{% url 'get-mini-node-info' dataset.short_name node.url_id %}?se=0&sb=0">
                             <i class="help grey circle icon"></i></span>
                         </span>
+                    </td>
+                    <td>
+                        <div class="w3-light-grey w3-round" style="width: 150px;">
+                            <div class="w3-container w3-round w3-blue" style="width:{{ node.nb_ground_truth|percent_goal }}%; text-align: center; padding-left:0px; padding-right:0px; min-width:15%;">{{ node.nb_ground_truth }}</div>
+                        </div>
                     </td>
                     <td class="right aligned">
                         <a href= "{% url 'contribute-validate-annotations-category' dataset.short_name node.url_id %}"

--- a/datasets/templates/datasets/dataset_taxonomy_table_choose.html
+++ b/datasets/templates/datasets/dataset_taxonomy_table_choose.html
@@ -35,7 +35,8 @@
         <thead>
             <tr>
                 <th>Category</th>
-                <th><div data-tooltip="Indicates how close we are from reaching our first goal (100 ground truth in each category)">Goal</div></th>
+                <th><div data-tooltip="Candidate annotations validated by more than one user, with majority agreement on the presence of a sound category in an audio sample">
+            # ground truth</div></th>
                 <th></th>
             </tr>
         </thead>
@@ -65,9 +66,7 @@
                         </span>
                     </td>
                     <td>
-                        <div class="w3-light-grey w3-round" style="width: 150px;">
-                            <div class="w3-container w3-round w3-blue" style="width:{{ node.nb_ground_truth|percent_goal }}%; text-align: center; padding-left:0px; padding-right:0px; min-width:15%;">{{ node.nb_ground_truth }}</div>
-                        </div>
+                        {% goal_progress_bar node.nb_ground_truth %}
                     </td>
                     <td class="right aligned">
                         <a href= "{% url 'contribute-validate-annotations-category' dataset.short_name node.url_id %}"

--- a/datasets/templates/datasets/dataset_taxonomy_table_search.html
+++ b/datasets/templates/datasets/dataset_taxonomy_table_search.html
@@ -1,7 +1,10 @@
+{% load dataset_templatetags %}
+
 <table id="dataset_contents" class="ui unstackable table" width="100%">
     <thead>
         <tr>
-            <th>Categories </th>
+            <th>Category</th>
+            <th><div data-tooltip="Indicates how close we are from reaching our first goal (100 ground truth in each category)">Goal</div></th>
             <th></th>
         </tr>
     </thead>
@@ -13,6 +16,11 @@
                       ajax_url="{% url 'get-mini-node-info' dataset.short_name node.url_id %}?se=0&sb=0">
                     <i class="help grey circle icon"></i>
                 </span>
+            </td>
+            <td>
+                <div class="w3-light-grey w3-round" style="width: 150px;">
+                    <div class="w3-container w3-round w3-blue" style="width:{{ node.nb_ground_truth|percent_goal }}%; text-align: center; padding-left:0px; padding-right:0px; min-width:15%;">{{ node.nb_ground_truth }}</div>
+                </div>
             </td>
             <td class="right aligned"><a href="{% url 'contribute-validate-annotations-category' dataset.short_name node.url_id %}?na={{ new_annotations }}&mt={{ maintainer_task }}"
                                          class="blue ui button right labeled icon"> Choose <i class="checkmark box icon"></i></a></td>

--- a/datasets/templates/datasets/dataset_taxonomy_table_search.html
+++ b/datasets/templates/datasets/dataset_taxonomy_table_search.html
@@ -4,7 +4,8 @@
     <thead>
         <tr>
             <th>Category</th>
-            <th><div data-tooltip="Indicates how close we are from reaching our first goal (100 ground truth in each category)">Goal</div></th>
+            <th><div data-tooltip="Candidate annotations validated by more than one user, with majority agreement on the presence of a sound category in an audio sample">
+            # ground truth</div></th>
             <th></th>
         </tr>
     </thead>
@@ -18,9 +19,7 @@
                 </span>
             </td>
             <td>
-                <div class="w3-light-grey w3-round" style="width: 150px;">
-                    <div class="w3-container w3-round w3-blue" style="width:{{ node.nb_ground_truth|percent_goal }}%; text-align: center; padding-left:0px; padding-right:0px; min-width:15%;">{{ node.nb_ground_truth }}</div>
-                </div>
+                {% goal_progress_bar node.nb_ground_truth %}
             </td>
             <td class="right aligned"><a href="{% url 'contribute-validate-annotations-category' dataset.short_name node.url_id %}?na={{ new_annotations }}&mt={{ maintainer_task }}"
                                          class="blue ui button right labeled icon"> Choose <i class="checkmark box icon"></i></a></td>

--- a/datasets/templates/datasets/goal_progress_bar.html
+++ b/datasets/templates/datasets/goal_progress_bar.html
@@ -1,0 +1,9 @@
+{% load dataset_templatetags %}
+<div class="w3-light-grey w3-round" style="width: 150px;" data-tooltip=
+        {% if num_ground_truth >= 100 %}
+            "This category has completed our first goal of gathering 100 samples"
+        {% else %}
+            "This category has reached {{ num_ground_truth }} samples out of our goal of 100"
+        {% endif %}>
+    <div class="w3-container w3-round w3-blue" style="width:{{ num_ground_truth|percent_goal }}%; text-align: center; padding-left:0px; padding-right:0px; min-width:15%; {% if num_ground_truth < 100 %}background-color:#00b4b4!important;{% endif %}">{{ num_ground_truth }}</div>
+</div>

--- a/datasets/templatetags/dataset_templatetags.py
+++ b/datasets/templatetags/dataset_templatetags.py
@@ -141,3 +141,8 @@ def percent_goal(value):
         return value
     else:
         return 100
+
+
+@register.inclusion_tag('datasets/goal_progress_bar.html', takes_context=False)
+def goal_progress_bar(value):
+    return {'num_ground_truth': value}

--- a/datasets/templatetags/dataset_templatetags.py
+++ b/datasets/templatetags/dataset_templatetags.py
@@ -134,3 +134,10 @@ def fs_embed(value):
     embed_code = '<iframe frameborder="0" scrolling="no" src="https://www.freesound.org/embed/sound/iframe/{0}/simple/medium_no_info/?spec=1&td=1" width="130" height="80"></iframe>'
     return embed_code.format(str(value))
 
+
+@register.filter()
+def percent_goal(value):
+    if value < 100:
+        return value
+    else:
+        return 100


### PR DESCRIPTION
This PR aims at implementing #136.

- Add a template for showing a category goal progress bar (callable with `goal_progress_bar` template tag)
- Add goal progress bar to _explore_ & _choose_ tables.

The goal of 100 is hard-coded for now. Maybe we could add it to `Dataset` model.