### PR TITLE
Monitor sound

### DIFF
--- a/datasets/templates/datasets/curate_sounds.html
+++ b/datasets/templates/datasets/curate_sounds.html
@@ -154,7 +154,12 @@
     </script>
     <div class="ui basic segment">
         <center>
-            <h3>Listen to the following sound and add labels!</h3>
+            <h3>
+                Listen to the following sound and add labels! 
+                <a class="ui icon" target="blank" href="{% url 'monitor-sound' dataset.short_name freesound_sound_id %}">
+                    <i class="ui recycle icon"></i>
+                </a>
+            </h3>
             <div style="float:right;"><a href="javascript:void(0);" onclick="openFreesoundSoundPage('{{ freesound_sound_id }}');">
                 see in <img class="ui image" style="width: 80px;" src="{% static 'img/freesound_logo_color.png' %}"></a></div>
             {{ freesound_sound_id| fs_embed_large | safe }}

--- a/monitor/templates/monitor/monitor_sound.html
+++ b/monitor/templates/monitor/monitor_sound.html
@@ -1,0 +1,90 @@
+{% extends "base.html" %}
+{% load humanize %}
+{% load static %}
+{% load general_templatetags %}
+{% load dataset_templatetags %}
+{% block title %}Monitor sound {{freesound_id}}{% endblock title %}
+{% block extra_head %}
+{% load_sound_player_files %}
+{% endblock extra_head%}
+
+
+{% block content %}
+
+    <h1>Sound with Freesound id {{sound.freesound_id}}</h1>
+    <center>
+        {{ sound.freesound_id| fs_embed_large | safe }}
+    </center>
+    <br>
+
+    <div class="title">
+        <h2 class="ui header">Ground truth annotations</h2>
+    </div>
+    <div class="content">
+        <table class="ui unstackable table" width="100%">
+            <thead>
+                <tr>
+                    <th class="center aligned">Category</th>
+                    <th class="center aligned">Precense</th>
+                    <th class="center aligned">From propagation</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for category, presence, from_propgation in ground_truth_annotations %}
+                <tr {% if color == 'g' %}bgcolor="#E8E8E8"{% endif %}>
+                    <td class="center aligned">
+                        {{ category }}
+                    </td>
+                    <td class="center aligned">
+                        {{ presence }}
+                    </td>
+                    <td class="center aligned">
+                        {{ from_propgation }}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <br><br>
+
+    <div class="title">
+        <h2 class="ui header">Votes submitted to the related candidate annotations</h2>
+    </div>
+    <div class="content">
+        <table class="ui unstackable table" width="100%">
+            <thead>
+                <tr>
+                    <th class="center aligned">Category</th>
+                    <th class="center aligned">Vote</th>
+                    <th class="center aligned">Date</th>
+                    <th class="center aligned">User</th>
+                    <th class="center aligned">Curation Task</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for category, vote, user, date, expert, color in contribs %}
+                <tr {% if color == 'g' %}bgcolor="#E8E8E8"{% endif %}>
+                    <td class="center aligned">
+                        {{ category }}
+                    </td>
+                    <td class="center aligned">
+                        {{ vote }}
+                    </td>
+                    <td class="center aligned">
+                        {{ date |date:"D d M Y"}}
+                    </td>
+                    <td class="center aligned">
+                        {{ user }}
+                    </td>
+                    <td class="center aligned">
+                        {{ expert }}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+{% endblock %}

--- a/monitor/urls.py
+++ b/monitor/urls.py
@@ -7,5 +7,6 @@ urlpatterns = [
     re_path(r'^(?P<short_name>[^\/]+)/monitor_category/(?P<node_id>[^\/]+)/$', monitor_category, name='monitor-category'),
     re_path(r'^(?P<short_name>[^\/]+)/monitor_user/(?P<user_id>[^\/]+)/$', monitor_user, name='monitor-user'),
     re_path(r'^(?P<short_name>[^\/]+)/mapping_category/(?P<node_id>[^\/]+)/$', mapping_category, name='mapping-category'),
-    re_path(r'^(?P<short_name>[^\/]+)/sound_player/(?P<freesound_id>[^\/]+)/$', player, name='sound-player')
+    re_path(r'^(?P<short_name>[^\/]+)/sound_player/(?P<freesound_id>[^\/]+)/$', player, name='sound-player'),
+    re_path(r'^(?P<short_name>[^\/]+)/monitor_sound/(?P<freesound_id>[^\/]+)/$', monitor_sound, name='monitor-sound'),
 ]

--- a/monitor/views.py
+++ b/monitor/views.py
@@ -289,6 +289,8 @@ def mapping_category(request, short_name, node_id):
 
 def monitor_sound(request, short_name, freesound_id):
     dataset = get_object_or_404(Dataset, short_name=short_name)
+    if not dataset.user_is_maintainer(request.user):
+        return HttpResponseRedirect(reverse('dataset', args=[dataset.short_name]))
     sound = get_object_or_404(Sound, freesound_id=freesound_id)
     sound_dataset = sound.sounddataset_set.filter(dataset=dataset).first()
     candidate_annotations = sound_dataset.candidate_annotations.all().select_related('taxonomy_node') \


### PR DESCRIPTION
This PR adds a monitor sound page which aims at facilitating the monitoring of the work of our expert annotators. For a specific sound, the page lists the ground truth annotations and all the votes submitted by all the users.