### PR TITLE
Use sentry-sdk instead of raven

### DIFF
--- a/datasets/templates/datasets/contribute_validate_annotations_category.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_category.html
@@ -4,7 +4,6 @@
 {% load general_templatetags %}
 {% block title %}Validate category {{ node.name }}{% endblock title %}
 {% block extra_head %}
-    {% sentry_install %}
     {% load_sound_player_files %}
 {% endblock %}
 
@@ -13,7 +12,7 @@
     var num_submit_trials = 0;
         function submitForm(){
             num_submit_trials += 1;
-            document.getElementById("submitButton").disabled = true; 
+            document.getElementById("submitButton").disabled = true;
             $.ajax({
                 type: "POST",
                 url: "{% url 'save-contribute-validate-annotations-per-category' %}",
@@ -40,16 +39,6 @@
                     }
                 },
                 error: function(e) {
-                    Raven.captureMessage('Error AJAX POST request votes submission', {
-                        tags: {
-                            status: e.status,
-                            status_text: e.statusText,
-                            response_text: e.responseText
-                        },
-                        extra: {
-                            response_text: e.responseText
-                        }
-                    });
                     if (num_submit_trials < 3) {
                         setTimeout(function() {submitForm();}, 500);
                     } else if (num_submit_trials < 5) {

--- a/datasets/templates/datasets/contribute_validate_annotations_category.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_category.html
@@ -4,7 +4,7 @@
 {% load general_templatetags %}
 {% block title %}Validate category {{ node.name }}{% endblock title %}
 {% block extra_head %}
-    {% raven_install %}
+    {% sentry_install %}
     {% load_sound_player_files %}
 {% endblock %}
 

--- a/datasets/templates/datasets/contribute_validate_annotations_category_easy.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_category_easy.html
@@ -4,7 +4,6 @@
 {% load general_templatetags %}
 {% block title %}Validate category {{ node.name }}{% endblock title %}
 {% block extra_head %}
-    {% sentry_install %}
     {% load_sound_player_files %}
 {% endblock %}
 
@@ -13,7 +12,7 @@
         var num_submit_trials = 0;
         function submitForm(){
             num_submit_trials += 1;
-            document.getElementById("submitButton").disabled = true; 
+            document.getElementById("submitButton").disabled = true;
             $.ajax({
                 type: "POST",
                 url: "{% url 'save-contribute-validate-annotations-per-category' %}",
@@ -36,16 +35,6 @@
                     }
                 },
                 error: function(e) {
-                    Raven.captureMessage('Error AJAX POST request votes submission', {
-                        tags: {
-                            status: e.status,
-                            status_text: e.statusText,
-                            response_text: e.responseText
-                        },
-                        extra: {
-                            response_text: e.responseText
-                        }
-                    });
                     if (num_submit_trials < 3) {
                         setTimeout(function() {submitForm();}, 500);
                     } else if (num_submit_trials < 5) {

--- a/datasets/templates/datasets/contribute_validate_annotations_category_easy.html
+++ b/datasets/templates/datasets/contribute_validate_annotations_category_easy.html
@@ -4,7 +4,7 @@
 {% load general_templatetags %}
 {% block title %}Validate category {{ node.name }}{% endblock title %}
 {% block extra_head %}
-    {% raven_install %}
+    {% sentry_install %}
     {% load_sound_player_files %}
 {% endblock %}
 

--- a/datasets/templatetags/general_templatetags.py
+++ b/datasets/templatetags/general_templatetags.py
@@ -83,14 +83,13 @@ def sound_player(dataset, freesound_sound_id, player_size, normalization=None):
 
 
 @register.simple_tag(takes_context=False)
-def raven_install():
-    sentry_full_dsn = settings.RAVEN_CONFIG['dsn']
-    if sentry_full_dsn:
-        sentry_dsn = ':'.join(sentry_full_dsn.split(':')[:2]) + '@' + sentry_full_dsn.split('@')[-1]
+def sentry_install():
+    sentry_dsn = settings.SENTRY_DSN
+    if sentry_dsn:
         return mark_safe('''
-            <script src="https://cdn.ravenjs.com/3.25.1/raven.min.js" crossorigin="anonymous"></script>
+            <script src="https://browser.sentry-cdn.com/5.15.5/bundle.min.js"></script>
             <script>
-                Raven.config('{}').install();
+                Sentry.init({{ dsn: '{}' }});
             </script>
                '''.format(sentry_dsn))
     else:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - dbvolume:/var/lib/postgresql/data/
+    command: postgres -F
   redis:
     image: redis
   web:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - 5543:5432
     env_file:
       - .env
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - dbvolume:/var/lib/postgresql/data/
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 volumes:
   dbvolume:
-  ipython:
+  roothome:
 services:
   db:
     image: postgres:9.6
@@ -24,7 +24,7 @@ services:
     volumes:
       - .:/code
       - /static/
-      - ipython:/root/.ipython
+      - roothome:/root
     command: dumb-init python manage.py runserver 0.0.0.0:8000
     depends_on:
       - db

--- a/freesound_datasets/settings.py
+++ b/freesound_datasets/settings.py
@@ -13,7 +13,8 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 import os
 import errno
 import dj_database_url
-import raven
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -84,7 +85,6 @@ INSTALLED_APPS = [
     'datasets',
     'monitor',
     'social_django',
-    'raven.contrib.django.raven_compat',
 ]
 
 MIDDLEWARE = [
@@ -178,13 +178,14 @@ USE_L10N = True
 
 USE_TZ = True
 
+SENTRY_DSN = os.getenv('SENTRY_DSN'),
+if SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[DjangoIntegration()],
+        send_default_pii=True
+    )
 
-RAVEN_CONFIG = {
-    'dsn': os.getenv('SENTRY_DSN'),
-    # If you are using git, you can also automatically configure the
-    # release based on the git info.
-    'release': raven.fetch_git_sha(os.path.dirname(os.pardir)),
-}
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.10/howto/static-files/

--- a/freesound_datasets/settings.py
+++ b/freesound_datasets/settings.py
@@ -178,7 +178,7 @@ USE_L10N = True
 
 USE_TZ = True
 
-SENTRY_DSN = os.getenv('SENTRY_DSN'),
+SENTRY_DSN = os.getenv('SENTRY_DSN')
 if SENTRY_DSN:
     sentry_sdk.init(
         dsn=SENTRY_DSN,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ markdown==2.6.8
 nltk==3.4.5
 psycopg2==2.7.7 --no-binary psycopg2
 pygments==2.2.0
-raven==6.4.0
+sentry-sdk==0.14.4
 redis==3.2.0
 social-auth-app-django==3.1.0
 uwsgi==2.0.18


### PR DESCRIPTION
This upgrades the use of raven to the new sentry sdk for python and javascript.
This also requires a change to asplab-configuration to set a different value for the SENTRY_DSN environment variable. Get it at https://logserver.mtg.upf.edu/settings/sentry/projects/freesound-datasets/keys/, or talk to me during deployment.

I've not tested the javascript side of things, and there are 2 remaining changes to be made:
https://github.com/MTG/freesound-datasets/blob/59bf36fe7d6a83aaaa5a42c51ac85e2e8f4eeb45/datasets/templates/datasets/contribute_validate_annotations_category_easy.html#L39

https://github.com/MTG/freesound-datasets/blob/59bf36fe7d6a83aaaa5a42c51ac85e2e8f4eeb45/datasets/templates/datasets/contribute_validate_annotations_category.html#L43

I was unsure about the syntax of these methods, and what to change them to. The method signature for `Sentry.captureMessage` seems to be different to the Raven one.
If we no longer need this capturing in js, we can remove it. Otherwise, we should work out how to set tags and report an exception with the new sdk.